### PR TITLE
Fix ERC-20 example

### DIFF
--- a/hardhat/erc20/README.md
+++ b/hardhat/erc20/README.md
@@ -22,8 +22,8 @@ if you don't yet have the yarn command installed locally.
 - To install the prerequisite packages, clone the examples repository:
 
 ```bash
-git clone https://github.com/bitfinity-network/bitfinity-examples.git
-cd bitfinity-examples/hardhat/erc20/
+git clone https://github.com/bitfinity-network/bitfinity-evm-examples.git
+cd bitfinity-evm-examples/hardhat/erc20/
 ```
 
 - Add your Bitfinity Private key (from MetaMask) to __.env__ file and

--- a/hardhat/erc20/scripts/deploy.js
+++ b/hardhat/erc20/scripts/deploy.js
@@ -34,6 +34,8 @@ async function main() {
     1000000,
     {
       nonce: await deployerWallet.getTransactionCount(),
+      gasLimit: 3000000,
+      gasPrice: 10,
     }
   );
   await watermelonToken.deployed();


### PR DESCRIPTION
This fixes the URL of the repository in the instructions.
This also adds `gasLimit` and `gasPrice` parameters to the deployment script
in order to avoid `Error: cannot estimate gas; transaction may fail or may require manual gas limit`

`gasLimit = 30M` was chosen based on the documentation:
https://docs.bitfinity.network/evm/opcodes#gas-limit

`gasPrice = 10` is the minimum accepted gas price.